### PR TITLE
Support for .recessrc file

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var chalk = require('chalk');
 var recess = require('recess');
+var RcLoader = require('rcloader');
 
 // prevent RECESS from reading files
 recess.Constructor.prototype.read = function () {
@@ -14,6 +15,8 @@ recess.Constructor.prototype.read = function () {
 
 module.exports = function (options) {
 	options = options || {};
+
+	var rcLoader = new RcLoader('.recessrc', options);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -28,6 +31,7 @@ module.exports = function (options) {
 			return;
 		}
 
+		options = rcLoader.for(file.path);
 		options.contents = file.contents.toString();
 
 		recess(file.path, options, function (err, results) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "chalk": "^0.5.1",
     "gulp-util": "^3.0.0",
     "recess": "^1.1.9",
-    "through2": "^0.5.1"
+    "through2": "^0.5.1",
+    "rcloader": "^0.1.2"
   },
   "devDependencies": {
     "jshint": "*",

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,12 @@ gulp.task('default', function () {
 
 ## API
 
-The `compress` and `compile` options from RECESS are intentionally missing. Separate tasks like [gulp-csso](https://github.com/ben-eb/gulp-csso) and [gulp-less](https://github.com/plus3network/gulp-less) will do a much better job.
+Options can be specified programmatically as part of the task configuration using the options below.
+Additionally or alternatively, you can use a `.recessrc` file to specify the options.
+
+The `compress` and `compile` options from RECESS are intentionally missing. Separate tasks
+like [gulp-csso](https://github.com/ben-eb/gulp-csso) and [gulp-less](https://github.com/plus3network/gulp-less)
+will do a much better job.
 
 ### recess(options)
 


### PR DESCRIPTION
This PR adds support for reading options from a `.recessrc` file, as you would expect from similar plugins such as `gulp-jshint`, etc.

Also happy to do the equivalent for the `grunt-recess` plugin if you're happy with the implementation here.
