### PR TITLE
Emit addition recess error information when error occurs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ module.exports = function (options) {
 	options = options || {};
 
 	var rcLoader = new RcLoader('.recessrc', options);
-	var recessError;
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -36,11 +35,10 @@ module.exports = function (options) {
 		recess(file.path, options, function (err, results) {
 			if (err) {
 				err.forEach(function (el) {
-					recessError = new gutil.PluginError('gulp-recess', el, {
+					var recessError = new gutil.PluginError('gulp-recess', el, {
 						showStack: false
 					});
 
-					recessError.fileName = file.path;
 					recessError.recess = {
 						message: el.message,
 						filename: el.filename,


### PR DESCRIPTION
This commit lets us do fun things like this gist: https://gist.github.com/shellscape/d60b941e78736c3ccd82 when an error occurs. 

The `fileName` property was being lost when PluginError was instantiated. (PluginError's constructors are problematic and inconsistent, I've opened an issue with gulp-util about it). So I'm manually attaching it to the instance to ensure that it's not lost.
