### PR TITLE
map the LessError object to a real Error instance for consumption by gulp-util.PluginError.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,19 @@ module.exports = function (options) {
 		recess(file.path, options, function (err, results) {
 			if (err) {
 				err.forEach(function (el) {
-					var recessError = new gutil.PluginError('gulp-recess', el, {
-						fileName: file.path,
+					var recessError;
+					var realError = new Error(el.message);
+
+					// el is an instance of LessError, which does not inherit
+					// from Error. PluginError expects an instance of Error.
+					// create a real Error and map LessError properties to it.
+					realError.columnNumber = el.column;
+					realError.fileName = el.filename;
+					realError.lineNumber = el.line;
+					realError.stack = el.stack;
+					realError.type = el.name;
+
+					recessError = new gutil.PluginError('gulp-recess', realError, {
 						showStack: false
 					});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-recess",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Lint CSS and LESS with RECESS",
   "license": "MIT",
   "repository": "sindresorhus/gulp-recess",


### PR DESCRIPTION
LESS errors that trickle down through RECESS are an instance of a custom object; `LessError`. Because `PluginError` expects an instance of `Error` in it's constructor, map LessError to Error and pass that real `Error` instance to `PluginError`.

Verified that properties are retained after the mapping within `realError` and after it's passed to `PluginError`.
